### PR TITLE
likecollective-indexer: add staking_rank to /book-nft/{address} response

### DIFF
--- a/likecollective-indexer/internal/api/openapi/get_book_nft_evm_address.go
+++ b/likecollective-indexer/internal/api/openapi/get_book_nft_evm_address.go
@@ -16,7 +16,8 @@ func (h *openAPIHandler) BookNftEvmAddressGet(
 		return nil, err
 	}
 
-	apiBookNFT := model.MakeBookNFT(bookNFT)
+	apiBookNFT := model.MakeBookNFT(bookNFT.NFTClass)
+	apiBookNFT.StakingRank.SetTo(bookNFT.StakingRank)
 
 	return &apiBookNFT, nil
 }

--- a/likecollective-indexer/internal/database/nft_class.go
+++ b/likecollective-indexer/internal/database/nft_class.go
@@ -12,6 +12,11 @@ import (
 	"github.com/holiman/uint256"
 )
 
+type NFTClassWithRank struct {
+	*ent.NFTClass
+	StakingRank int
+}
+
 type NFTClassRepository interface {
 	QueryNFTClasses(
 		ctx context.Context,
@@ -26,7 +31,7 @@ type NFTClassRepository interface {
 	QueryNFTClass(
 		ctx context.Context,
 		address string,
-	) (*ent.NFTClass, error)
+	) (*NFTClassWithRank, error)
 
 	QueryNFTClassesByAddresses(
 		ctx context.Context,
@@ -59,6 +64,18 @@ type nftClassRepository struct {
 
 func MakeNFTClassRepository(dbService Service) NFTClassRepository {
 	return &nftClassRepository{dbService: dbService}
+}
+
+func (r *nftClassRepository) computeStakingRank(ctx context.Context, stakedAmount typeutil.Uint256) (int, error) {
+	amountStr := (*uint256.Int)(stakedAmount).String()
+	higherCount, err := r.dbService.Client().NFTClass.Query().Where(func(s *sql.Selector) {
+		s.Where(sql.GT(nftclass.FieldStakedAmount, 0))
+		s.Where(sql.GT(nftclass.FieldStakedAmount, amountStr))
+	}).Count(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return higherCount + 1, nil
 }
 
 func (r *nftClassRepository) QueryNFTClasses(
@@ -109,7 +126,7 @@ func (r *nftClassRepository) QueryNFTClasses(
 func (r *nftClassRepository) QueryNFTClass(
 	ctx context.Context,
 	address string,
-) (*ent.NFTClass, error) {
+) (*NFTClassWithRank, error) {
 	nftClass, err := r.dbService.Client().NFTClass.Query().Where(func(s *sql.Selector) {
 		s.Where(sql.GT(nftclass.FieldStakedAmount, 0))
 	}).Where(
@@ -119,7 +136,15 @@ func (r *nftClassRepository) QueryNFTClass(
 		return nil, err
 	}
 
-	return nftClass, nil
+	rank, err := r.computeStakingRank(ctx, nftClass.StakedAmount)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NFTClassWithRank{
+		NFTClass:    nftClass,
+		StakingRank: rank,
+	}, nil
 }
 
 func (r *nftClassRepository) QueryNFTClassesByAddresses(

--- a/likecollective-indexer/openapi/api/oas_json_gen.go
+++ b/likecollective-indexer/openapi/api/oas_json_gen.go
@@ -541,13 +541,20 @@ func (s *BookNFT) encodeFields(e *jx.Encoder) {
 		e.FieldStart("number_of_stakers")
 		e.Int(s.NumberOfStakers)
 	}
+	{
+		if s.StakingRank.Set {
+			e.FieldStart("staking_rank")
+			s.StakingRank.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfBookNFT = [4]string{
+var jsonFieldsNameOfBookNFT = [5]string{
 	0: "evm_address",
 	1: "staked_amount",
 	2: "last_staked_at",
 	3: "number_of_stakers",
+	4: "staking_rank",
 }
 
 // Decode decodes BookNFT from json.
@@ -600,6 +607,16 @@ func (s *BookNFT) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"number_of_stakers\"")
+			}
+		case "staking_rank":
+			if err := func() error {
+				s.StakingRank.Reset()
+				if err := s.StakingRank.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"staking_rank\"")
 			}
 		default:
 			return d.Skip()
@@ -2739,6 +2756,41 @@ func (s OptDateTime) MarshalJSON() ([]byte, error) {
 func (s *OptDateTime) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d, json.DecodeDateTime)
+}
+
+// Encode encodes int as json.
+func (o OptInt) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Int(int(o.Value))
+}
+
+// Decode decodes int from json.
+func (o *OptInt) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptInt to nil")
+	}
+	o.Set = true
+	v, err := d.Int()
+	if err != nil {
+		return err
+	}
+	o.Value = int(v)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptInt) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptInt) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
 }
 
 // Encode encodes string as json.

--- a/likecollective-indexer/openapi/api/oas_schemas_gen.go
+++ b/likecollective-indexer/openapi/api/oas_schemas_gen.go
@@ -212,6 +212,7 @@ type BookNFT struct {
 	StakedAmount    Uint256     `json:"staked_amount"`
 	LastStakedAt    NilDateTime `json:"last_staked_at"`
 	NumberOfStakers int         `json:"number_of_stakers"`
+	StakingRank     OptInt      `json:"staking_rank"`
 }
 
 // GetEvmAddress returns the value of EvmAddress.
@@ -234,6 +235,11 @@ func (s *BookNFT) GetNumberOfStakers() int {
 	return s.NumberOfStakers
 }
 
+// GetStakingRank returns the value of StakingRank.
+func (s *BookNFT) GetStakingRank() OptInt {
+	return s.StakingRank
+}
+
 // SetEvmAddress sets the value of EvmAddress.
 func (s *BookNFT) SetEvmAddress(val EvmAddress) {
 	s.EvmAddress = val
@@ -252,6 +258,11 @@ func (s *BookNFT) SetLastStakedAt(val NilDateTime) {
 // SetNumberOfStakers sets the value of NumberOfStakers.
 func (s *BookNFT) SetNumberOfStakers(val int) {
 	s.NumberOfStakers = val
+}
+
+// SetStakingRank sets the value of StakingRank.
+func (s *BookNFT) SetStakingRank(val OptInt) {
+	s.StakingRank = val
 }
 
 // Ref: #/components/schemas/BookNFTStakeDelta

--- a/likecollective-indexer/openapi/schema.yaml
+++ b/likecollective-indexer/openapi/schema.yaml
@@ -1139,6 +1139,8 @@ components:
           nullable: true
         number_of_stakers:
           type: integer
+        staking_rank:
+          type: integer
       required:
         - evm_address
         - staked_amount


### PR DESCRIPTION
Compute global staking rank per book using COUNT of books with higher staked_amount. Rank is optional in the schema and only populated on the single-book endpoint where position in a sorted list is not available.