### PR TITLE
likenft-indexer: avoid seqscan and COUNT on paginated account queries

### DIFF
--- a/likenft-indexer/ent/migrate/migrations/20260423105001_Add lower owner_address indexes.sql
+++ b/likenft-indexer/ent/migrate/migrations/20260423105001_Add lower owner_address indexes.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "nft_owner_address_lower" ON "nfts" (LOWER("owner_address"));
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "nftclass_owner_address_lower" ON "nft_classes" (LOWER("owner_address"));
+RESET statement_timeout;
+RESET lock_timeout;

--- a/likenft-indexer/ent/migrate/migrations/atlas.sum
+++ b/likenft-indexer/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8HrAtlCsmqw1LPSO79ZqTqSCBTQBemSe3Cv7iKtffRQ=
+h1:Ufg+vOBuwFM+gN0vUTrIUu9cApcdp5WD3eftVB7p2nM=
 20250128141722.sql h1:ryXRWHhorhSGucN6U492mujs+SXglSD9AFpGmDqybvM=
 20250401092803.sql h1:JIb0qYQjuR1cWEJ2rmv14t/P1XRYgj9bU+X9oTj8+Ds=
 20250402104835.sql h1:1K1uXbyv1QsRv3Ld80bKWVxfug4O+QNwMya6b/g5/1w=
@@ -10,3 +10,4 @@ h1:8HrAtlCsmqw1LPSO79ZqTqSCBTQBemSe3Cv7iKtffRQ=
 20250718084522_Add acquire_book_nft_events columns to nft_class table.sql h1:Ur7W+Man3FvaDpBWWrT7K4/MgVHeUiqDdc1HD8AC7CU=
 20250722021109_Rename nftclass_acquire_book_nft_events_score to eta.sql h1:rp+NnzjOK17MtIwbINhozrE8QXPC/8VUv2r88mqtmPw=
 20251014134139_Add updater_addresses to nftclasses.sql h1:UxPgC9lShgKsyLLm+iJRsiZPyZlLy03HTbA3PvyFpyk=
+20260423105001_Add lower owner_address indexes.sql h1:e1C8btioGxek8QzaD6jrb0T3Q4X9vO1KfbkrRGRsEPE=

--- a/likenft-indexer/internal/database/account.go
+++ b/likenft-indexer/internal/database/account.go
@@ -92,11 +92,6 @@ func (r *accountRepository) GetTokenAccountsByBookNFT(
 			),
 		)
 
-	count, err = q.Count(ctx)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-
 	q = pagination.HandlePagination(q)
 
 	accounts, err = q.All(ctx)
@@ -104,6 +99,7 @@ func (r *accountRepository) GetTokenAccountsByBookNFT(
 		return nil, 0, 0, err
 	}
 
+	count = len(accounts)
 	nextKey = 0
 	if len(accounts) > 0 {
 		nextKey = accounts[len(accounts)-1].ID

--- a/likenft-indexer/internal/database/nft.go
+++ b/likenft-indexer/internal/database/nft.go
@@ -82,11 +82,6 @@ func (r *nftRepository) QueryNFTsByEvmAddress(
 		nft.OwnerAddressEqualFold(accountEvmAddress),
 	)
 
-	count, err = q.Count(ctx)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-
 	q = pagination.HandlePagination(q)
 
 	nfts, err = q.All(ctx)
@@ -94,6 +89,7 @@ func (r *nftRepository) QueryNFTsByEvmAddress(
 		return nil, 0, 0, err
 	}
 
+	count = len(nfts)
 	nextKey = 0
 	if len(nfts) > 0 {
 		nextKey = nfts[len(nfts)-1].ID
@@ -114,11 +110,6 @@ func (r *nftRepository) QueryNFTsByBookNFTAndEvmAddress(
 			nft.OwnerAddressEqualFold(accountEvmAddress),
 		)
 
-	count, err = q.Count(ctx)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-
 	q = pagination.HandlePagination(q)
 
 	nfts, err = q.All(ctx)
@@ -126,6 +117,7 @@ func (r *nftRepository) QueryNFTsByBookNFTAndEvmAddress(
 		return nil, 0, 0, err
 	}
 
+	count = len(nfts)
 	nextKey = 0
 	if len(nfts) > 0 {
 		nextKey = nfts[len(nfts)-1].ID

--- a/likenft-indexer/internal/database/nftclass.go
+++ b/likenft-indexer/internal/database/nftclass.go
@@ -157,11 +157,6 @@ func (r *nftClassRepository) QueryNFTClasses(
 	q = contractLevelMetadataEQ.ApplyEQ(q)
 	q = contractLevelMetadataNEQ.ApplyNEQ(q)
 
-	count, err = q.Count(ctx)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-
 	q = pagination.HandlePagination(q)
 
 	nftClasses, err = q.All(ctx)
@@ -169,6 +164,7 @@ func (r *nftClassRepository) QueryNFTClasses(
 		return nil, 0, 0, err
 	}
 
+	count = len(nftClasses)
 	nextKey = 0
 	if len(nftClasses) > 0 {
 		nextKey = nftClasses[len(nftClasses)-1].ID
@@ -194,11 +190,6 @@ func (r *nftClassRepository) QueryNFTClassesByAccountTokens(
 	q = contractLevelMetadataEQ.ApplyEQ(q)
 	q = contractLevelMetadataNEQ.ApplyNEQ(q)
 
-	count, err = q.Count(ctx)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-
 	q = pagination.HandlePagination(q)
 
 	nftClasses, err = q.All(ctx)
@@ -206,6 +197,7 @@ func (r *nftClassRepository) QueryNFTClassesByAccountTokens(
 		return nil, 0, 0, err
 	}
 
+	count = len(nftClasses)
 	nextKey = 0
 	if len(nftClasses) > 0 {
 		nextKey = nftClasses[len(nftClasses)-1].ID
@@ -231,17 +223,14 @@ func (r *nftClassRepository) QueryNFTClassesByAccountTokensWithNFTID(
 	q = contractLevelMetadataEQ.ApplyEQ(q)
 	q = contractLevelMetadataNEQ.ApplyNEQ(q)
 
-	count, err = q.Count(ctx)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-
 	q = pagination.HandlePagination(q)
 
 	classes, err := q.All(ctx)
 	if err != nil {
 		return nil, 0, 0, err
 	}
+
+	count = len(classes)
 
 	classAddresses := make([]string, len(classes))
 	for i, c := range classes {
@@ -304,11 +293,6 @@ func (r *nftClassRepository) QueryNFTClassesByEvmAddress(
 	q = contractLevelMetadataEQ.ApplyEQ(q)
 	q = contractLevelMetadataNEQ.ApplyNEQ(q)
 
-	count, err = q.Count(ctx)
-	if err != nil {
-		return nil, 0, 0, err
-	}
-
 	q = pagination.HandlePagination(q)
 
 	nftClasses, err = q.All(ctx)
@@ -316,6 +300,7 @@ func (r *nftClassRepository) QueryNFTClassesByEvmAddress(
 		return nil, 0, 0, err
 	}
 
+	count = len(nftClasses)
 	nextKey = 0
 	if len(nftClasses) > 0 {
 		nextKey = nftClasses[len(nftClasses)-1].ID

--- a/likenft-indexer/openapi/api/oas_schemas_gen.go
+++ b/likenft-indexer/openapi/api/oas_schemas_gen.go
@@ -1790,7 +1790,10 @@ func (o OptUint64) Or(d Uint64) Uint64 {
 // Ref: #/components/schemas/PaginationResponse
 type PaginationResponse struct {
 	NextKey int `json:"next_key"`
-	Count   int `json:"count"`
+	// Always equal to `data.length`. Kept for schema compatibility.
+	//
+	// Deprecated: schema marks this property as deprecated.
+	Count int `json:"count"`
 }
 
 // GetNextKey returns the value of NextKey.

--- a/likenft-indexer/openapi/schema.yaml
+++ b/likenft-indexer/openapi/schema.yaml
@@ -1003,6 +1003,8 @@ components:
           type: integer
         count:
           type: integer
+          deprecated: true
+          description: Always equal to `data.length`. Kept for schema compatibility.
       required:
         - next_key
         - count


### PR DESCRIPTION
TokenBookNFTsByAccount and similar endpoints were timing out (pq: canceling statement due to user request) for wallets with many NFTs. Two root causes:

- ent's OwnerAddressEqualFold generates LOWER(col) = LOWER($1), which cannot use the plain b-tree index on owner_address. Add functional indexes on LOWER(owner_address) for nfts and nft_classes so these predicates can use an index scan.
- Each paginated repository function also ran q.Count(ctx) before pagination, re-executing the same filter to compute a total. Drop the pre-page count in all 7 pagination-returning functions and set count = len(results) after q.All.

PaginationResponse.count now always equals data.length; marked deprecated in the schema so new clients prefer data.length directly.