### PR TITLE
migration-backend: Default ETH_AMOUNT_TO_AIRDROP_ON_MIGRATE to 0

### DIFF
--- a/migration-backend/cmd/worker/config/config.go
+++ b/migration-backend/cmd/worker/config/config.go
@@ -27,7 +27,7 @@ type EnvConfig struct {
 	LikecoinAPIHTTPTimeoutSeconds   int    `envconfig:"LIKECOIN_API_HTTP_TIMEOUT_SECONDS" default:"10"`
 	LikeNFTIndexerBaseURL           string `envconfig:"LIKENFT_INDEXER_BASE_URL"`
 	LikeNFTIndexerAPIKey            string `envconfig:"LIKENFT_INDEXER_API_KEY"`
-	EthAmountToAirdropOnMigrate     string `envconfig:"ETH_AMOUNT_TO_AIRDROP_ON_MIGRATE" default:"0.00005"`
+	EthAmountToAirdropOnMigrate     string `envconfig:"ETH_AMOUNT_TO_AIRDROP_ON_MIGRATE" default:"0"`
 
 	InitialNewClassOwner              string   `envconfig:"INITIAL_NEW_CLASS_OWNER"`
 	InitialNewClassMinters            []string `envconfig:"INITIAL_NEW_CLASS_MINTERS"`


### PR DESCRIPTION
Disable the migration ETH airdrop by default so deployments must opt in explicitly via env var instead of relying on the implicit 0.00005 fallback.