### PR TITLE
likenft-indexer: record token acquisition time and expose token_updat…

### DIFF
--- a/likenft-indexer/cmd/cli/cmd/backfill_nft_updated_at.go
+++ b/likenft-indexer/cmd/cli/cmd/backfill_nft_updated_at.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"likenft-indexer/cmd/cli/context"
+	"likenft-indexer/internal/database"
+
+	"github.com/spf13/cobra"
+)
+
+var BackfillNFTUpdatedAtCmd = &cobra.Command{
+	Use:   "backfill-nft-updated-at",
+	Short: "Backfill nfts.updated_at from Transfer event block timestamps",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+		logger := context.LoggerFromContext(ctx)
+		mylogger := logger.WithGroup("BackfillNFTUpdatedAt")
+
+		dbService := database.New()
+		nftRepository := database.MakeNFTRepository(dbService)
+
+		updatedCount, err := nftRepository.BackfillUpdatedAtFromTransferEvents(ctx, mylogger)
+
+		if err != nil {
+			panic(err)
+		}
+
+		mylogger.Info("done", "updated", updatedCount)
+	},
+}

--- a/likenft-indexer/cmd/cli/cmd/root.go
+++ b/likenft-indexer/cmd/cli/cmd/root.go
@@ -38,6 +38,7 @@ func Execute(
 
 func init() {
 	rootCmd.AddCommand(AcquireContractEvents)
+	rootCmd.AddCommand(BackfillNFTUpdatedAtCmd)
 	rootCmd.AddCommand(ProcessAllEVMEventCmd)
 	rootCmd.AddCommand(ProcessEVMEventCmd)
 	rootCmd.AddCommand(RecalculateEvmEventsCmd)

--- a/likenft-indexer/internal/api/openapi/model/nft.go
+++ b/likenft-indexer/internal/api/openapi/model/nft.go
@@ -29,7 +29,7 @@ func MakeNFT(e *ent.NFT) api.NFT {
 		YoutubeURL:      MakeOptString(e.YoutubeURL),
 		OwnerAddress:    e.OwnerAddress,
 		MintedAt:        e.MintedAt,
-		UpdatedAt:       e.MintedAt,
+		UpdatedAt:       e.UpdatedAt,
 	}
 }
 

--- a/likenft-indexer/internal/api/openapi/model/nftclass.go
+++ b/likenft-indexer/internal/api/openapi/model/nftclass.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"likenft-indexer/ent"
-	"likenft-indexer/ent/schema/typeutil"
 	"likenft-indexer/internal/database"
 	"likenft-indexer/internal/evm/model"
 	"likenft-indexer/openapi/api"
@@ -11,10 +10,11 @@ import (
 )
 
 func MakeNFTClass(e *ent.NFTClass) (*api.BookNFT, error) {
-	return MakeNFTClassWithTokenID(e, nil)
+	return MakeNFTClassWithToken(&database.NFTClassWithNFTID{NFTClass: e})
 }
 
-func MakeNFTClassWithTokenID(e *ent.NFTClass, tokenID *typeutil.Uint64) (*api.BookNFT, error) {
+func MakeNFTClassWithToken(t *database.NFTClassWithNFTID) (*api.BookNFT, error) {
+	e := t.NFTClass
 	var (
 		opensea                 *model.ContractLevelMetadataOpenSea
 		metadataAdditionalProps = make(map[string]jx.Raw)
@@ -44,7 +44,8 @@ func MakeNFTClassWithTokenID(e *ent.NFTClass, tokenID *typeutil.Uint64) (*api.Bo
 		MintedAt:            e.MintedAt,
 		UpdatedAt:           e.UpdatedAt,
 		Owner:               MakeOptAccount(e.Edges.Owner),
-		TokenID:             MakeOptUint64(tokenID),
+		TokenID:             MakeOptUint64(t.NFTID),
+		TokenUpdatedAt:      MakeOptDateTime(t.TokenUpdatedAt),
 	}, nil
 }
 

--- a/likenft-indexer/internal/api/openapi/model/opt_date_time.go
+++ b/likenft-indexer/internal/api/openapi/model/opt_date_time.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"time"
+
+	"likenft-indexer/openapi/api"
+)
+
+func MakeOptDateTime(t *time.Time) api.OptDateTime {
+	if t == nil {
+		return api.OptDateTime{
+			Value: time.Time{},
+			Set:   false,
+		}
+	}
+	return api.NewOptDateTime(*t)
+}

--- a/likenft-indexer/internal/api/openapi/token_book_nfts_by_account.go
+++ b/likenft-indexer/internal/api/openapi/token_book_nfts_by_account.go
@@ -38,7 +38,7 @@ func (h *OpenAPIHandler) TokenBookNFTsByAccount(ctx context.Context, params api.
 	apiBookNFTs := make([]api.BookNFT, len(nftClassWithTokenIDs))
 
 	for i, nftClassWithTokenID := range nftClassWithTokenIDs {
-		apiNFTClass, err := model.MakeNFTClassWithTokenID(nftClassWithTokenID.NFTClass, nftClassWithTokenID.NFTID)
+		apiNFTClass, err := model.MakeNFTClassWithToken(nftClassWithTokenID)
 		if err != nil {
 			return nil, err
 		}

--- a/likenft-indexer/internal/database/nft.go
+++ b/likenft-indexer/internal/database/nft.go
@@ -2,10 +2,14 @@ package database
 
 import (
 	"context"
+	"log/slog"
 	"math/big"
+	"strconv"
+	"strings"
 	"time"
 
 	"likenft-indexer/ent"
+	"likenft-indexer/ent/evmevent"
 	"likenft-indexer/ent/nft"
 	"likenft-indexer/ent/nftclass"
 	"likenft-indexer/ent/schema/typeutil"
@@ -51,7 +55,13 @@ type NFTRepository interface {
 		TokenID *big.Int,
 		NewOwnerAddress string,
 		NewOwner *ent.Account,
+		UpdatedAt time.Time,
 	) error
+
+	BackfillUpdatedAtFromTransferEvents(
+		ctx context.Context,
+		logger *slog.Logger,
+	) (updatedCount int, err error)
 }
 
 type nftRepository struct {
@@ -212,6 +222,7 @@ func (r *nftRepository) UpdateOwner(
 	tokenID *big.Int,
 	newOwnerAddress string,
 	newOwner *ent.Account,
+	updatedAt time.Time,
 ) error {
 	err := WithTx(ctx, r.dbService.Client(), func(tx *ent.Tx) error {
 		_, err := tx.NFT.Query().
@@ -228,6 +239,7 @@ func (r *nftRepository) UpdateOwner(
 		return tx.NFT.Update().
 			SetOwnerAddress(newOwnerAddress).
 			SetOwner(newOwner).
+			SetUpdatedAt(updatedAt).
 			Where(
 				nft.ContractAddressEqualFold(contractAddress),
 				nft.TokenIDEQ(typeutil.Uint64(tokenID.Uint64())),
@@ -238,4 +250,78 @@ func (r *nftRepository) UpdateOwner(
 		return err
 	}
 	return nil
+}
+
+// Backfills nfts.updated_at from the block time of each token's latest
+// Transfer/TransferWithMemo event. Historical rows only carried the indexing
+// time (and transfers never bumped updated_at before this was recorded), so
+// this makes updated_at mean "when the current owner acquired the token".
+// Idempotent — safe to re-run.
+func (r *nftRepository) BackfillUpdatedAtFromTransferEvents(
+	ctx context.Context,
+	logger *slog.Logger,
+) (updatedCount int, err error) {
+	// topic3 holds the tokenId of Transfer/TransferWithMemo as a decimal string
+	// (see logconverter.ConvertLogToEvmEvent).
+	var rows []struct {
+		Address   string    `json:"address"`
+		Topic3    string    `json:"topic3"`
+		Timestamp time.Time `json:"max_timestamp"`
+	}
+	err = r.dbService.Client().EVMEvent.Query().
+		Where(
+			evmevent.NameIn("Transfer", "TransferWithMemo"),
+			evmevent.Removed(false),
+			// A failed event's ownership change never reached the nfts row,
+			// so its timestamp must not be stamped either.
+			evmevent.StatusEQ(evmevent.StatusProcessed),
+			evmevent.Topic3NotNil(),
+		).
+		GroupBy(evmevent.FieldAddress, evmevent.FieldTopic3).
+		Aggregate(ent.As(ent.Max(evmevent.FieldTimestamp), "max_timestamp")).
+		Scan(ctx, &rows)
+	if err != nil {
+		return 0, err
+	}
+
+	// Update by primary key: matching on contract_address would compile
+	// EqualFold to ILIKE, which cannot use the btree index and would turn
+	// every update into a full table scan.
+	nfts, err := r.dbService.Client().NFT.Query().
+		Select(nft.FieldID, nft.FieldContractAddress, nft.FieldTokenID, nft.FieldUpdatedAt).
+		All(ctx)
+	if err != nil {
+		return 0, err
+	}
+	nftByKey := make(map[string]*ent.NFT, len(nfts))
+	for _, n := range nfts {
+		nftByKey[makeNFTBackfillKey(n.ContractAddress, uint64(n.TokenID))] = n
+	}
+
+	for i, row := range rows {
+		tokenID, err := strconv.ParseUint(row.Topic3, 10, 64)
+		if err != nil {
+			logger.Warn("skipping unparsable topic3", "address", row.Address, "topic3", row.Topic3)
+			continue
+		}
+		n, exists := nftByKey[makeNFTBackfillKey(row.Address, tokenID)]
+		if !exists || n.UpdatedAt.Equal(row.Timestamp) {
+			continue
+		}
+		err = r.dbService.Client().NFT.UpdateOneID(n.ID).
+			SetUpdatedAt(row.Timestamp).
+			Exec(ctx)
+		if err != nil {
+			return updatedCount, err
+		}
+		updatedCount++
+		if (i+1)%10000 == 0 {
+			logger.Info("backfill progress", "processed", i+1, "total", len(rows), "updated", updatedCount)
+		}
+	}
+	return updatedCount, nil
+}
+
+func makeNFTBackfillKey(contractAddress string, tokenID uint64) string {
+	return strings.ToLower(contractAddress) + "/" + strconv.FormatUint(tokenID, 10)
 }

--- a/likenft-indexer/internal/database/nft_test.go
+++ b/likenft-indexer/internal/database/nft_test.go
@@ -1,0 +1,225 @@
+package database_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"math/big"
+	"testing"
+	"time"
+
+	"likenft-indexer/ent"
+	"likenft-indexer/ent/evmevent"
+	"likenft-indexer/ent/schema/typeutil"
+	"likenft-indexer/internal/database"
+
+	"github.com/ethereum/go-ethereum/common"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type nftTestUtil struct {
+}
+
+func slogNop() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func (nftTestUtil) makeNFT(
+	nftRepository database.NFTRepository,
+	nftClass *ent.NFTClass,
+	tokenID int64,
+	ownerAddress string,
+	owner *ent.Account,
+) (*ent.NFT, error) {
+	return nftRepository.GetOrCreate(
+		context.Background(),
+		nftClass.Address,
+		big.NewInt(tokenID),
+		"https://example.com/token",
+		"https://example.com/image.png",
+		nil,
+		nil,
+		"Test NFT",
+		"Test NFT",
+		nil,
+		nil,
+		nil,
+		nil,
+		ownerAddress,
+		owner,
+		nftClass,
+	)
+}
+
+func TestNFTUpdateOwnerSetsUpdatedAt(t *testing.T) {
+	classUtil := &nftClassUtil{}
+	util := &nftTestUtil{}
+
+	Convey("Test NFT UpdateOwner sets updated_at", t, func() {
+		dbService := newTestService(t)
+		defer dbService.Close()
+
+		accountRepository := database.MakeAccountRepository(dbService)
+		nftClassRepository := database.MakeNFTClassRepository(dbService)
+		nftRepository := database.MakeNFTRepository(dbService)
+
+		accountOrigin, err := accountRepository.GetOrCreateAccount(context.Background(), &ent.Account{
+			EvmAddress: common.HexToAddress("0x1000000000000000000000000000000000000001").String(),
+		})
+		So(err, ShouldBeNil)
+
+		accountNew, err := accountRepository.GetOrCreateAccount(context.Background(), &ent.Account{
+			EvmAddress: common.HexToAddress("0x1000000000000000000000000000000000000002").String(),
+		})
+		So(err, ShouldBeNil)
+
+		nftClassAddress := common.HexToAddress("0x8Ed946DF65a6dD97fcD071c995710b9bf14361c3").String()
+		err = classUtil.makeNFTClass(nftClassRepository, accountOrigin, nftClassAddress, 100)
+		So(err, ShouldBeNil)
+		nftClass, err := nftClassRepository.QueryNFTClassByAddress(context.Background(), nftClassAddress)
+		So(err, ShouldBeNil)
+
+		_, err = util.makeNFT(nftRepository, nftClass, 0, accountOrigin.EvmAddress, accountOrigin)
+		So(err, ShouldBeNil)
+
+		transferredAt := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		err = nftRepository.UpdateOwner(
+			context.Background(),
+			nftClassAddress,
+			big.NewInt(0),
+			accountNew.EvmAddress,
+			accountNew,
+			transferredAt,
+		)
+		So(err, ShouldBeNil)
+
+		n := dbService.Client().NFT.Query().OnlyX(context.Background())
+		So(n.OwnerAddress, ShouldEqual, accountNew.EvmAddress)
+		So(n.UpdatedAt.Unix(), ShouldEqual, transferredAt.Unix())
+	})
+}
+
+func TestQueryNFTClassesByAccountTokensWithNFTIDTokenUpdatedAt(t *testing.T) {
+	classUtil := &nftClassUtil{}
+	util := &nftTestUtil{}
+
+	Convey("Test token_updated_at is max across owned copies", t, func() {
+		dbService := newTestService(t)
+		defer dbService.Close()
+
+		accountRepository := database.MakeAccountRepository(dbService)
+		nftClassRepository := database.MakeNFTClassRepository(dbService)
+		nftRepository := database.MakeNFTRepository(dbService)
+
+		account, err := accountRepository.GetOrCreateAccount(context.Background(), &ent.Account{
+			EvmAddress: common.HexToAddress("0x1000000000000000000000000000000000000001").String(),
+		})
+		So(err, ShouldBeNil)
+
+		nftClassAddress := common.HexToAddress("0x8Ed946DF65a6dD97fcD071c995710b9bf14361c3").String()
+		err = classUtil.makeNFTClass(nftClassRepository, account, nftClassAddress, 100)
+		So(err, ShouldBeNil)
+		nftClass, err := nftClassRepository.QueryNFTClassByAddress(context.Background(), nftClassAddress)
+		So(err, ShouldBeNil)
+
+		earlier := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+		later := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+		for _, token := range []struct {
+			tokenID    int64
+			acquiredAt time.Time
+		}{
+			{tokenID: 0, acquiredAt: later},
+			{tokenID: 1, acquiredAt: earlier},
+		} {
+			_, err = util.makeNFT(nftRepository, nftClass, token.tokenID, account.EvmAddress, account)
+			So(err, ShouldBeNil)
+			err = nftRepository.UpdateOwner(
+				context.Background(),
+				nftClassAddress,
+				big.NewInt(token.tokenID),
+				account.EvmAddress,
+				account,
+				token.acquiredAt,
+			)
+			So(err, ShouldBeNil)
+		}
+
+		rows, count, _, err := nftClassRepository.QueryNFTClassesByAccountTokensWithNFTID(
+			context.Background(),
+			account.EvmAddress,
+			nil,
+			nil,
+			database.NFTClassPagination{},
+		)
+		So(err, ShouldBeNil)
+		So(count, ShouldEqual, 1)
+		So(rows[0].TokenUpdatedAt, ShouldNotBeNil)
+		So(rows[0].TokenUpdatedAt.Unix(), ShouldEqual, later.Unix())
+	})
+}
+
+func TestBackfillUpdatedAtFromTransferEvents(t *testing.T) {
+	classUtil := &nftClassUtil{}
+	util := &nftTestUtil{}
+
+	Convey("Test backfill from transfer events", t, func() {
+		dbService := newTestService(t)
+		defer dbService.Close()
+
+		accountRepository := database.MakeAccountRepository(dbService)
+		nftClassRepository := database.MakeNFTClassRepository(dbService)
+		nftRepository := database.MakeNFTRepository(dbService)
+		evmEventRepository := database.MakeEVMEventRepository(dbService)
+
+		account, err := accountRepository.GetOrCreateAccount(context.Background(), &ent.Account{
+			EvmAddress: common.HexToAddress("0x1000000000000000000000000000000000000001").String(),
+		})
+		So(err, ShouldBeNil)
+
+		nftClassAddress := common.HexToAddress("0x8Ed946DF65a6dD97fcD071c995710b9bf14361c3").String()
+		err = classUtil.makeNFTClass(nftClassRepository, account, nftClassAddress, 100)
+		So(err, ShouldBeNil)
+		nftClass, err := nftClassRepository.QueryNFTClassByAddress(context.Background(), nftClassAddress)
+		So(err, ShouldBeNil)
+
+		_, err = util.makeNFT(nftRepository, nftClass, 0, account.EvmAddress, account)
+		So(err, ShouldBeNil)
+
+		mintedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+		transferredAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+		tokenIDStr := "0"
+		events := []*ent.EVMEvent{}
+		for i, ts := range []time.Time{mintedAt, transferredAt} {
+			events = append(events, &ent.EVMEvent{
+				BlockNumber:      typeutil.Uint64(uint64(100 + i)),
+				TransactionIndex: 0,
+				LogIndex:         0,
+				TransactionHash:  common.HexToHash(big.NewInt(int64(i)).String()).String(),
+				BlockHash:        common.HexToHash(big.NewInt(int64(i)).String()).String(),
+				Address:          nftClassAddress,
+				ChainID:          typeutil.Uint64(99999),
+				Topic0:           "Transfer",
+				Topic0Hex:        "topic0hex",
+				Topic3:           &tokenIDStr,
+				Removed:          false,
+				Status:           evmevent.StatusProcessed,
+				Name:             "Transfer",
+				Signature:        "Transfer(address,address,uint256)",
+				Timestamp:        ts,
+			})
+		}
+		_, err = evmEventRepository.InsertEvmEventsIfNeeded(context.Background(), events)
+		So(err, ShouldBeNil)
+
+		updatedCount, err := nftRepository.BackfillUpdatedAtFromTransferEvents(
+			context.Background(),
+			slogNop(),
+		)
+		So(err, ShouldBeNil)
+		So(updatedCount, ShouldEqual, 1)
+
+		n := dbService.Client().NFT.Query().OnlyX(context.Background())
+		So(n.UpdatedAt.Unix(), ShouldEqual, transferredAt.Unix())
+	})
+}

--- a/likenft-indexer/internal/database/nftclass.go
+++ b/likenft-indexer/internal/database/nftclass.go
@@ -19,6 +19,9 @@ import (
 type NFTClassWithNFTID struct {
 	NFTClass *ent.NFTClass
 	NFTID    *typeutil.Uint64
+	// Latest updated_at among the account's owned tokens of this class,
+	// i.e. when the account most recently acquired a copy.
+	TokenUpdatedAt *time.Time
 }
 
 type NFTClassRepository interface {
@@ -250,18 +253,27 @@ func (r *nftClassRepository) QueryNFTClassesByAccountTokensWithNFTID(
 	}
 
 	nftIDMap := make(map[string]*typeutil.Uint64)
+	tokenUpdatedAtMap := make(map[string]time.Time)
 	for _, n := range nfts {
 		if _, exists := nftIDMap[n.ContractAddress]; !exists {
 			nftID := typeutil.Uint64(n.TokenID)
 			nftIDMap[n.ContractAddress] = &nftID
 		}
+		if n.UpdatedAt.After(tokenUpdatedAtMap[n.ContractAddress]) {
+			tokenUpdatedAtMap[n.ContractAddress] = n.UpdatedAt
+		}
 	}
 
 	result := make([]*NFTClassWithNFTID, len(classes))
 	for i, c := range classes {
+		var tokenUpdatedAt *time.Time
+		if t, exists := tokenUpdatedAtMap[c.Address]; exists {
+			tokenUpdatedAt = &t
+		}
 		result[i] = &NFTClassWithNFTID{
-			NFTClass: c,
-			NFTID:    nftIDMap[c.Address],
+			NFTClass:       c,
+			NFTID:          nftIDMap[c.Address],
+			TokenUpdatedAt: tokenUpdatedAt,
 		}
 	}
 

--- a/likenft-indexer/internal/logic/evmeventprocessor/transfer.go
+++ b/likenft-indexer/internal/logic/evmeventprocessor/transfer.go
@@ -134,6 +134,7 @@ func (e *transferProcessor) Process(
 		tokenId,
 		transferEvent.To.Hex(),
 		owner,
+		evmEvent.Timestamp,
 	)
 
 	if err != nil {

--- a/likenft-indexer/internal/logic/evmeventprocessor/transfer_with_memo.go
+++ b/likenft-indexer/internal/logic/evmeventprocessor/transfer_with_memo.go
@@ -153,6 +153,7 @@ func (e *transferWithMemoProcessor) Process(
 		tokenId,
 		transferWithMemoEvent.To.Hex(),
 		owner,
+		evmEvent.Timestamp,
 	)
 
 	if err != nil {

--- a/likenft-indexer/openapi/api/oas_json_gen.go
+++ b/likenft-indexer/openapi/api/oas_json_gen.go
@@ -5,6 +5,7 @@ package api
 import (
 	"math/bits"
 	"strconv"
+	"time"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
@@ -387,9 +388,15 @@ func (s *BookNFT) encodeFields(e *jx.Encoder) {
 			s.TokenID.Encode(e)
 		}
 	}
+	{
+		if s.TokenUpdatedAt.Set {
+			e.FieldStart("token_updated_at")
+			s.TokenUpdatedAt.Encode(e, json.EncodeDateTime)
+		}
+	}
 }
 
-var jsonFieldsNameOfBookNFT = [17]string{
+var jsonFieldsNameOfBookNFT = [18]string{
 	0:  "id",
 	1:  "address",
 	2:  "name",
@@ -407,6 +414,7 @@ var jsonFieldsNameOfBookNFT = [17]string{
 	14: "updated_at",
 	15: "owner",
 	16: "token_id",
+	17: "token_updated_at",
 }
 
 // Decode decodes BookNFT from json.
@@ -623,6 +631,16 @@ func (s *BookNFT) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"token_id\"")
+			}
+		case "token_updated_at":
+			if err := func() error {
+				s.TokenUpdatedAt.Reset()
+				if err := s.TokenUpdatedAt.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"token_updated_at\"")
 			}
 		default:
 			return d.Skip()
@@ -3353,6 +3371,41 @@ func (s OptContractLevelMetadata) MarshalJSON() ([]byte, error) {
 func (s *OptContractLevelMetadata) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
+}
+
+// Encode encodes time.Time as json.
+func (o OptDateTime) Encode(e *jx.Encoder, format func(*jx.Encoder, time.Time)) {
+	if !o.Set {
+		return
+	}
+	format(e, o.Value)
+}
+
+// Decode decodes time.Time from json.
+func (o *OptDateTime) Decode(d *jx.Decoder, format func(*jx.Decoder) (time.Time, error)) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptDateTime to nil")
+	}
+	o.Set = true
+	v, err := format(d)
+	if err != nil {
+		return err
+	}
+	o.Value = v
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptDateTime) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e, json.EncodeDateTime)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptDateTime) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d, json.DecodeDateTime)
 }
 
 // Encode encodes Erc721MetadataAttributeDisplayType as json.

--- a/likenft-indexer/openapi/api/oas_schemas_gen.go
+++ b/likenft-indexer/openapi/api/oas_schemas_gen.go
@@ -97,6 +97,9 @@ type BookNFT struct {
 	UpdatedAt           time.Time                `json:"updated_at"`
 	Owner               OptAccount               `json:"owner"`
 	TokenID             OptUint64                `json:"token_id"`
+	// Latest acquisition time among the requested account's owned tokens of this class; only populated
+	// by /account/{address}/token-booknfts.
+	TokenUpdatedAt OptDateTime `json:"token_updated_at"`
 }
 
 // GetID returns the value of ID.
@@ -184,6 +187,11 @@ func (s *BookNFT) GetTokenID() OptUint64 {
 	return s.TokenID
 }
 
+// GetTokenUpdatedAt returns the value of TokenUpdatedAt.
+func (s *BookNFT) GetTokenUpdatedAt() OptDateTime {
+	return s.TokenUpdatedAt
+}
+
 // SetID sets the value of ID.
 func (s *BookNFT) SetID(val int) {
 	s.ID = val
@@ -267,6 +275,11 @@ func (s *BookNFT) SetOwner(val OptAccount) {
 // SetTokenID sets the value of TokenID.
 func (s *BookNFT) SetTokenID(val OptUint64) {
 	s.TokenID = val
+}
+
+// SetTokenUpdatedAt sets the value of TokenUpdatedAt.
+func (s *BookNFT) SetTokenUpdatedAt(val OptDateTime) {
+	s.TokenUpdatedAt = val
 }
 
 type BookNFTsByAccountOK struct {
@@ -1505,6 +1518,52 @@ func (o OptContractLevelMetadataNEQ) Get() (v ContractLevelMetadataNEQ, ok bool)
 
 // Or returns value if set, or given parameter if does not.
 func (o OptContractLevelMetadataNEQ) Or(d ContractLevelMetadataNEQ) ContractLevelMetadataNEQ {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptDateTime returns new OptDateTime with value set to v.
+func NewOptDateTime(v time.Time) OptDateTime {
+	return OptDateTime{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptDateTime is optional time.Time.
+type OptDateTime struct {
+	Value time.Time
+	Set   bool
+}
+
+// IsSet returns true if OptDateTime was set.
+func (o OptDateTime) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptDateTime) Reset() {
+	var v time.Time
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptDateTime) SetTo(v time.Time) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptDateTime) Get() (v time.Time, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptDateTime) Or(d time.Time) time.Time {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/likenft-indexer/openapi/schema.yaml
+++ b/likenft-indexer/openapi/schema.yaml
@@ -893,6 +893,12 @@ components:
           $ref: "#/components/schemas/Account"
         token_id:
           $ref: "#/components/schemas/Uint64"
+        token_updated_at:
+          type: string
+          format: date-time
+          description: >-
+            Latest acquisition time among the requested account's owned tokens
+            of this class; only populated by /account/{address}/token-booknfts.
       required:
         - id
         - address


### PR DESCRIPTION
…ed_at

- Set nfts.updated_at to the transfer event's block time in UpdateOwner so it means "when the current owner acquired the token"
- Add optional token_updated_at (max across the account's owned copies) to /account/{address}/token-booknfts rows
- Return the token's real updated_at (was minted_at) in /account/tokens
- Add backfill-nft-updated-at CLI to stamp existing rows from stored Transfer/TransferWithMemo events